### PR TITLE
Speedup blocks decoding

### DIFF
--- a/gba/video/codec_dxtv.cpp
+++ b/gba/video/codec_dxtv.cpp
@@ -227,11 +227,11 @@ namespace DXTV
             // get motion-compensated block info
             const uint16_t blockInfo = *dataPtr16++;
             const bool fromPrev = blockInfo & BLOCK_FROM_PREV;
-            const uint16_t *srcPtr16 = reinterpret_cast<const uint16_t *>(fromPrev ? prevPtr32 : currPtr32);
+            auto srcPtr16 = reinterpret_cast<const uint16_t *>(fromPrev ? prevPtr32 : currPtr32);
             // convert offsets to signed values
             constexpr int32_t halfRange = (1 << BLOCK_MOTION_BITS) / 2 - 1;
-            const int32_t offsetX = static_cast<int32_t>(blockInfo & BLOCK_MOTION_MASK) - halfRange;
-            const int32_t offsetY = static_cast<int32_t>((blockInfo >> BLOCK_MOTION_Y_SHIFT) & BLOCK_MOTION_MASK) - halfRange;
+            const auto offsetX = static_cast<int32_t>(blockInfo & BLOCK_MOTION_MASK) - halfRange;
+            const auto offsetY = static_cast<int32_t>((blockInfo >> BLOCK_MOTION_Y_SHIFT) & BLOCK_MOTION_MASK) - halfRange;
             // calculate start of block to copy
             srcPtr16 += offsetY * LineStride16 + offsetX;
             // copy pixels to output block

--- a/gba/video/codec_dxtv.cpp
+++ b/gba/video/codec_dxtv.cpp
@@ -170,10 +170,9 @@ namespace DXTV
     FORCEINLINE auto decodeBlock<4>(const uint16_t *dataPtr16, uint32_t *currPtr32, const uint32_t *prevPtr32, const uint32_t LineStride16) -> const uint16_t *
     {
         auto currPtr16 = reinterpret_cast<uint16_t *>(currPtr32);
-
         if (*dataPtr16 & BLOCK_IS_REF)
         {
-          	// get motion-compensated block info
+            // get motion-compensated block info
             const uint16_t blockInfo = *dataPtr16++;
             const bool fromPrev = blockInfo & BLOCK_FROM_PREV;
             const uint16_t *srcPtr16 = reinterpret_cast<const uint16_t *>(fromPrev ? prevPtr32 : currPtr32);
@@ -181,14 +180,14 @@ namespace DXTV
             constexpr int32_t halfRange = (1 << BLOCK_MOTION_BITS) / 2 - 1;
             const int32_t offsetX = static_cast<int32_t>(blockInfo & BLOCK_MOTION_MASK) - halfRange;
             const int32_t offsetY = static_cast<int32_t>((blockInfo >> BLOCK_MOTION_Y_SHIFT) & BLOCK_MOTION_MASK) - halfRange;
-			// calculate start of block to copy
+            // calculate start of block to copy
             srcPtr16 += offsetY * LineStride16 + offsetX;
             // copy pixels to output block
             copyBlock<4>(currPtr32, srcPtr16, LineStride16);
         }
         else
         {
-          	// get DXT block colors
+            // get DXT block colors
             dataPtr16 = DXT::getBlockColors(dataPtr16, blockColors);
             // Unroll and decode 4x4 pixel color indices
             uint16_t indices0 = *dataPtr16++;
@@ -218,25 +217,24 @@ namespace DXTV
     FORCEINLINE auto decodeBlock<8>(const uint16_t *dataPtr16, uint32_t *currPtr32, const uint32_t *prevPtr32, const uint32_t LineStride16) -> const uint16_t *
     {
         auto currPtr16 = reinterpret_cast<uint16_t *>(currPtr32);
-
         if (*dataPtr16 & BLOCK_IS_REF)
         {
-          	// get motion-compensated block info
+            // get motion-compensated block info
             const uint16_t blockInfo = *dataPtr16++;
             const bool fromPrev = blockInfo & BLOCK_FROM_PREV;
             const uint16_t *srcPtr16 = reinterpret_cast<const uint16_t *>(fromPrev ? prevPtr32 : currPtr32);
-			// convert offsets to signed values
+            // convert offsets to signed values
             constexpr int32_t halfRange = (1 << BLOCK_MOTION_BITS) / 2 - 1;
             const int32_t offsetX = static_cast<int32_t>(blockInfo & BLOCK_MOTION_MASK) - halfRange;
             const int32_t offsetY = static_cast<int32_t>((blockInfo >> BLOCK_MOTION_Y_SHIFT) & BLOCK_MOTION_MASK) - halfRange;
-			// calculate start of block to copy
+            // calculate start of block to copy
             srcPtr16 += offsetY * LineStride16 + offsetX;
             // copy pixels to output block
             copyBlock<8>(currPtr32, srcPtr16, LineStride16);
         }
         else
         {
-          	// get DXT block colors
+            // get DXT block colors
             dataPtr16 = DXT::getBlockColors(dataPtr16, blockColors);
             for (int row = 0; row < 8; ++row)
             {

--- a/gba/video/codec_dxtv.cpp
+++ b/gba/video/codec_dxtv.cpp
@@ -241,19 +241,29 @@ namespace DXTV
         {
             // get DXT block colors
             dataPtr16 = DXT::getBlockColors(dataPtr16, blockColors);
-            for (int row = 0; row < 8; ++row)
+            for (uint32_t i = 0; i < 4; ++i)
             {
-                uint16_t indices = *dataPtr16++;
-                uint16_t *dst = currPtr16;
-                // unrolled: each pixel = 2-bit index from indices
-                dst[0] = blockColors[(indices >> 0)  & 0x3];
-                dst[1] = blockColors[(indices >> 2)  & 0x3];
-                dst[2] = blockColors[(indices >> 4)  & 0x3];
-                dst[3] = blockColors[(indices >> 6)  & 0x3];
-                dst[4] = blockColors[(indices >> 8)  & 0x3];
-                dst[5] = blockColors[(indices >> 10) & 0x3];
-                dst[6] = blockColors[(indices >> 12) & 0x3];
-                dst[7] = blockColors[(indices >> 14) & 0x3];
+                // read all indices for next 16 pixels
+                uint16_t indices0 = *dataPtr16++;
+                uint16_t indices1 = *dataPtr16++;
+                // decode 2x8 pixels
+                currPtr16[0] = blockColors[(indices0 >> 0)  & 0x3];
+                currPtr16[1] = blockColors[(indices0 >> 2)  & 0x3];
+                currPtr16[2] = blockColors[(indices0 >> 4)  & 0x3];
+                currPtr16[3] = blockColors[(indices0 >> 6)  & 0x3];
+                currPtr16[4] = blockColors[(indices0 >> 8)  & 0x3];
+                currPtr16[5] = blockColors[(indices0 >> 10) & 0x3];
+                currPtr16[6] = blockColors[(indices0 >> 12) & 0x3];
+                currPtr16[7] = blockColors[(indices0 >> 14) & 0x3];
+                currPtr16 += LineStride16;
+                currPtr16[0] = blockColors[(indices1 >> 0)  & 0x3];
+                currPtr16[1] = blockColors[(indices1 >> 2)  & 0x3];
+                currPtr16[2] = blockColors[(indices1 >> 4)  & 0x3];
+                currPtr16[3] = blockColors[(indices1 >> 6)  & 0x3];
+                currPtr16[4] = blockColors[(indices1 >> 8)  & 0x3];
+                currPtr16[5] = blockColors[(indices1 >> 10) & 0x3];
+                currPtr16[6] = blockColors[(indices1 >> 12) & 0x3];
+                currPtr16[7] = blockColors[(indices1 >> 14) & 0x3];
                 currPtr16 += LineStride16;
             }
         }

--- a/gba/video/codec_dxtv.cpp
+++ b/gba/video/codec_dxtv.cpp
@@ -175,11 +175,11 @@ namespace DXTV
             // get motion-compensated block info
             const uint16_t blockInfo = *dataPtr16++;
             const bool fromPrev = blockInfo & BLOCK_FROM_PREV;
-            const uint16_t *srcPtr16 = reinterpret_cast<const uint16_t *>(fromPrev ? prevPtr32 : currPtr32);
+            auto srcPtr16 = reinterpret_cast<const uint16_t *>(fromPrev ? prevPtr32 : currPtr32);
             // convert offsets to signed values
             constexpr int32_t halfRange = (1 << BLOCK_MOTION_BITS) / 2 - 1;
-            const int32_t offsetX = static_cast<int32_t>(blockInfo & BLOCK_MOTION_MASK) - halfRange;
-            const int32_t offsetY = static_cast<int32_t>((blockInfo >> BLOCK_MOTION_Y_SHIFT) & BLOCK_MOTION_MASK) - halfRange;
+            const auto offsetX = static_cast<int32_t>(blockInfo & BLOCK_MOTION_MASK) - halfRange;
+            const auto offsetY = static_cast<int32_t>((blockInfo >> BLOCK_MOTION_Y_SHIFT) & BLOCK_MOTION_MASK) - halfRange;
             // calculate start of block to copy
             srcPtr16 += offsetY * LineStride16 + offsetX;
             // copy pixels to output block

--- a/gba/video/codec_dxtv.cpp
+++ b/gba/video/codec_dxtv.cpp
@@ -173,47 +173,42 @@ namespace DXTV
 
         if (*dataPtr16 & BLOCK_IS_REF)
         {
+          	// get motion-compensated block info
             const uint16_t blockInfo = *dataPtr16++;
             const bool fromPrev = blockInfo & BLOCK_FROM_PREV;
             const uint16_t *srcPtr16 = reinterpret_cast<const uint16_t *>(fromPrev ? prevPtr32 : currPtr32);
-
+            // convert offsets to signed values
             constexpr int32_t halfRange = (1 << BLOCK_MOTION_BITS) / 2 - 1;
             const int32_t offsetX = static_cast<int32_t>(blockInfo & BLOCK_MOTION_MASK) - halfRange;
             const int32_t offsetY = static_cast<int32_t>((blockInfo >> BLOCK_MOTION_Y_SHIFT) & BLOCK_MOTION_MASK) - halfRange;
-
+			// calculate start of block to copy
             srcPtr16 += offsetY * LineStride16 + offsetX;
+            // copy pixels to output block
             copyBlock<4>(currPtr32, srcPtr16, LineStride16);
         }
         else
         {
+          	// get DXT block colors
             dataPtr16 = DXT::getBlockColors(dataPtr16, blockColors);
-
-            // Unroll and decode 4x4 indices in just 2 reads
+            // Unroll and decode 4x4 pixel color indices
             uint16_t indices0 = *dataPtr16++;
             uint16_t indices1 = *dataPtr16++;
-
             uint16_t *dst = currPtr16;
-
             for (int row = 0; row < 2; ++row)
             {
                 uint16_t indices = (row == 0) ? indices0 : indices1;
-
                 dst[0] = blockColors[(indices >> 0) & 0x3];
                 dst[1] = blockColors[(indices >> 2) & 0x3];
                 dst[2] = blockColors[(indices >> 4) & 0x3];
                 dst[3] = blockColors[(indices >> 6) & 0x3];
-
                 dst += LineStride16;
-
                 dst[0] = blockColors[(indices >> 8) & 0x3];
                 dst[1] = blockColors[(indices >> 10) & 0x3];
                 dst[2] = blockColors[(indices >> 12) & 0x3];
                 dst[3] = blockColors[(indices >> 14) & 0x3];
-
                 dst += LineStride16;
             }
         }
-
         return dataPtr16;
     }
 
@@ -226,26 +221,27 @@ namespace DXTV
 
         if (*dataPtr16 & BLOCK_IS_REF)
         {
+          	// get motion-compensated block info
             const uint16_t blockInfo = *dataPtr16++;
             const bool fromPrev = blockInfo & BLOCK_FROM_PREV;
             const uint16_t *srcPtr16 = reinterpret_cast<const uint16_t *>(fromPrev ? prevPtr32 : currPtr32);
-
+			// convert offsets to signed values
             constexpr int32_t halfRange = (1 << BLOCK_MOTION_BITS) / 2 - 1;
             const int32_t offsetX = static_cast<int32_t>(blockInfo & BLOCK_MOTION_MASK) - halfRange;
             const int32_t offsetY = static_cast<int32_t>((blockInfo >> BLOCK_MOTION_Y_SHIFT) & BLOCK_MOTION_MASK) - halfRange;
-
+			// calculate start of block to copy
             srcPtr16 += offsetY * LineStride16 + offsetX;
+            // copy pixels to output block
             copyBlock<8>(currPtr32, srcPtr16, LineStride16);
         }
         else
         {
+          	// get DXT block colors
             dataPtr16 = DXT::getBlockColors(dataPtr16, blockColors);
-
             for (int row = 0; row < 8; ++row)
             {
                 uint16_t indices = *dataPtr16++;
                 uint16_t *dst = currPtr16;
-
                 // unrolled: each pixel = 2-bit index from indices
                 dst[0] = blockColors[(indices >> 0)  & 0x3];
                 dst[1] = blockColors[(indices >> 2)  & 0x3];
@@ -255,11 +251,9 @@ namespace DXTV
                 dst[5] = blockColors[(indices >> 10) & 0x3];
                 dst[6] = blockColors[(indices >> 12) & 0x3];
                 dst[7] = blockColors[(indices >> 14) & 0x3];
-
                 currPtr16 += LineStride16;
             }
         }
-
         return dataPtr16;
     }
 

--- a/gba/video/codec_dxtv.cpp
+++ b/gba/video/codec_dxtv.cpp
@@ -189,24 +189,29 @@ namespace DXTV
         {
             // get DXT block colors
             dataPtr16 = DXT::getBlockColors(dataPtr16, blockColors);
-            // Unroll and decode 4x4 pixel color indices
+            // read all 16 color indices
             uint16_t indices0 = *dataPtr16++;
             uint16_t indices1 = *dataPtr16++;
-            uint16_t *dst = currPtr16;
-            for (int row = 0; row < 2; ++row)
-            {
-                uint16_t indices = (row == 0) ? indices0 : indices1;
-                dst[0] = blockColors[(indices >> 0) & 0x3];
-                dst[1] = blockColors[(indices >> 2) & 0x3];
-                dst[2] = blockColors[(indices >> 4) & 0x3];
-                dst[3] = blockColors[(indices >> 6) & 0x3];
-                dst += LineStride16;
-                dst[0] = blockColors[(indices >> 8) & 0x3];
-                dst[1] = blockColors[(indices >> 10) & 0x3];
-                dst[2] = blockColors[(indices >> 12) & 0x3];
-                dst[3] = blockColors[(indices >> 14) & 0x3];
-                dst += LineStride16;
-            }
+            // write 4x4 color block
+            currPtr16[0] = blockColors[(indices0 >> 0) & 0x3];
+            currPtr16[1] = blockColors[(indices0 >> 2) & 0x3];
+            currPtr16[2] = blockColors[(indices0 >> 4) & 0x3];
+            currPtr16[3] = blockColors[(indices0 >> 6) & 0x3];
+            currPtr16 += LineStride16;
+            currPtr16[0] = blockColors[(indices0 >> 8) & 0x3];
+            currPtr16[1] = blockColors[(indices0 >> 10) & 0x3];
+            currPtr16[2] = blockColors[(indices0 >> 12) & 0x3];
+            currPtr16[3] = blockColors[(indices0 >> 14) & 0x3];
+            currPtr16 += LineStride16;
+            currPtr16[0] = blockColors[(indices1 >> 0) & 0x3];
+            currPtr16[1] = blockColors[(indices1 >> 2) & 0x3];
+            currPtr16[2] = blockColors[(indices1 >> 4) & 0x3];
+            currPtr16[3] = blockColors[(indices1 >> 6) & 0x3];
+            currPtr16 += LineStride16;
+            currPtr16[0] = blockColors[(indices1 >> 8) & 0x3];
+            currPtr16[1] = blockColors[(indices1 >> 10) & 0x3];
+            currPtr16[2] = blockColors[(indices1 >> 12) & 0x3];
+            currPtr16[3] = blockColors[(indices1 >> 14) & 0x3];
         }
         return dataPtr16;
     }


### PR DESCRIPTION
- Unrolled index unpacking logic to reduce bit-shifting and memory access overhead
